### PR TITLE
cardboard sdk scale is in meter unit adapt the scale of the sphere, s…

### DIFF
--- a/app/src/main/java/com/eje_c/rajawalicardboard/MyRenderer.java
+++ b/app/src/main/java/com/eje_c/rajawalicardboard/MyRenderer.java
@@ -18,12 +18,15 @@ public class MyRenderer extends RajawaliCardboardRenderer {
     @Override
     protected void initScene() {
 
-        Sphere sphere = createPhotoSphereWithTexture(new Texture("photo", R.drawable.zvirbloniu_parkas));
+        Sphere sphere = createPhotoSphereWithTexture(new Texture("photo", R.drawable.panorama));
 
         getCurrentScene().addChild(sphere);
 
         getCurrentCamera().setPosition(Vector3.ZERO);
         getCurrentCamera().setFieldOfView(100);
+
+        getCurrentCamera().setFarPlane(2);
+        getCurrentCamera().setNearPlane(0.000000000000001);
     }
 
     private static Sphere createPhotoSphereWithTexture(ATexture texture) {
@@ -37,7 +40,8 @@ public class MyRenderer extends RajawaliCardboardRenderer {
             throw new RuntimeException(e);
         }
 
-        Sphere sphere = new Sphere(50, 64, 32);
+        //cardboard sdk matrices are in meter unit, sphere should addapt to that scale
+        Sphere sphere = new Sphere(1, 128, 64);
         sphere.setScaleX(-1);
         sphere.setMaterial(material);
 

--- a/rajawalicardboard/src/main/java/org/rajawali3d/cardboard/RajawaliCardboardRenderer.java
+++ b/rajawalicardboard/src/main/java/org/rajawali3d/cardboard/RajawaliCardboardRenderer.java
@@ -50,7 +50,14 @@ public abstract class RajawaliCardboardRenderer extends RajawaliRenderer impleme
 
         // Apply the eye transformation to the camera
         eyeMatrix.setAll(eye.getEyeView());
-        eyeQuaternion.fromMatrix(eyeMatrix);
+        //the eye matrix need to be inverted, it is a model matrix not a camera pose
+
+        //the eye matrix contains also the information about the base line defined by the cardboard
+        //configuration. One eye (camera) is translated to the left one to the right. The translation
+        //is in meter unit.
+        //https://developers.google.com/cardboard/android/latest/reference/com/google/vrtoolkit/cardboard/Eye.html#public-methods_2
+        getCurrentCamera().setPosition(eyeMatrix.inverse().getTranslation());
+        eyeQuaternion.fromMatrix(eyeMatrix.inverse());
         getCurrentCamera().setOrientation(eyeQuaternion);
 
         render(ellapsedRealtime, deltaTime);


### PR DESCRIPTION
…et eye cameras correctly consider eye baseline, remove zvirbloniu_parks panorama (it is not a power of two texture and can crash on devices with low ram specs as of the high resolution)